### PR TITLE
'Con' has no attribute 'props'

### DIFF
--- a/examples/focus-last.py
+++ b/examples/focus-last.py
@@ -25,7 +25,7 @@ class FocusWatcher:
 
     def on_window_focus(self, i3conn, event):
         with self.window_list_lock:
-            window_id = event.container.props.id
+            window_id = event.container.id
             if window_id in self.window_list:
                 self.window_list.remove(window_id)
             self.window_list.insert(0, window_id)


### PR DESCRIPTION
In the current version , the window event (https://i3ipc-python.readthedocs.io/en/latest/events.html#i3ipc.Event.WINDOW) emits Con=<class 'i3ipc.con.Con'>
Con doesn't have a 'props' attribute:
https://i3ipc-python.readthedocs.io/en/latest/aio-con.html#i3ipc.aio.Con
I'm assuming that the variable 'id' on 'Con' would be representative