### PR TITLE
MANIFEST.in: Fix tests, add examples and docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,8 @@
 include README.rst LICENSE CHANGELOG.md pytest.ini requirements.txt .flake8 .style.yapf
+include Makefile
+include run-tests.py
 recursive-include test *.py
+include test/i3.config
+recursive-include examples *.md
+recursive-include examples *.py
+recursive-include docs *.rst


### PR DESCRIPTION
The tests depend on test/i3.config
examples and docs are helpful to redist to users.