### PR TITLE
i3-cycle-focus: kill on i3 'shutdown' event

### DIFF
--- a/examples/i3-cycle-focus.py
+++ b/examples/i3-cycle-focus.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+#
+# provides alt+tab functionality between windows, switching
+# between n windows; example i3 conf to use:
+#     exec_always --no-startup-id i3-cycle-focus.py --history 2
+#     bindsym $mod1+Tab exec --no-startup-id i3-cycle-focus.py --switch
 
 import os
 import socket
@@ -7,15 +12,19 @@ import threading
 from argparse import ArgumentParser
 import i3ipc
 
-SOCKET_FILE = '/tmp/i3-cycle-focus'
+SOCKET_FILE = '/tmp/.i3-cycle-focus.sock'
 MAX_WIN_HISTORY = 16
 UPDATE_DELAY = 2.0
 
+
+def on_shutdown(i3_conn, e):
+    os._exit(0)
 
 class FocusWatcher:
     def __init__(self):
         self.i3 = i3ipc.Connection()
         self.i3.on('window::focus', self.on_window_focus)
+        self.i3.on('shutdown', on_shutdown)
         self.listening_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         if os.path.exists(SOCKET_FILE):
             os.remove(SOCKET_FILE)


### PR DESCRIPTION
- add on_shutdown() handler;
- needs to be coupled with the daemon process being started from i3
  config using exec_always; this makes sure old process, referring to
  stale connection upon i3 restart/crash, gets cleaned up.