### PR TITLE
Add Sway specific fields to OutputReply() model

### DIFF
--- a/i3ipc/replies.py
+++ b/i3ipc/replies.py
@@ -91,6 +91,18 @@ class OutputReply(_BaseReply):
         ('primary', bool),
         ('current_workspace', str),
         ('rect', Rect),
+        # Sway only output fields:
+        ('make', str),
+        ('model', str),
+        ('serial', str),
+        ('scale', float),
+        ('transform', str),
+        ('max_render_time', int),
+        ('focused', bool),
+        ('dpms', bool),
+        ('subpixel_hinting', str),
+        ('modes', list),
+        ('current_mode', dict),
     ]
 
 


### PR DESCRIPTION
The new models omitted some Sway specific output i tems. These are mostly related to the hardware behind the outputs and are the only way to get this info under Sway (xrandr lists XWAYLAND[N])

This pull request adds the missing items.