### PR TITLE
examples/focus-last.py: handle multiple sessions and/or users safely

### DIFF
--- a/examples/focus-last.py
+++ b/examples/focus-last.py
@@ -3,11 +3,14 @@
 import os
 import socket
 import selectors
+import tempfile
 import threading
 from argparse import ArgumentParser
 import i3ipc
 
-SOCKET_FILE = '/tmp/i3_focus_last'
+SOCKET_DIR = '{}/i3_focus_last.{}{}'.format(
+    tempfile.gettempdir(), os.geteuid(), os.getenv("DISPLAY"))
+SOCKET_FILE = '{}/socket'.format(SOCKET_DIR)
 MAX_WIN_HISTORY = 15
 
 
@@ -15,6 +18,9 @@ class FocusWatcher:
     def __init__(self):
         self.i3 = i3ipc.Connection()
         self.i3.on('window::focus', self.on_window_focus)
+        # Make a directory with permissions that restrict access to
+        # the user only.
+        os.makedirs(SOCKET_DIR, mode=0o700, exist_ok=True)
         self.listening_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         if os.path.exists(SOCKET_FILE):
             os.remove(SOCKET_FILE)


### PR DESCRIPTION
Create the path to socket portably and such that when script is used
with multiple sessions by the same user or various users each session
gets its own socked which other users can not access.

This is achieved by using UID and DISPLAY in the path name, using the
tempfile module from stdlib to get the path for /tmp, and creating the
socket under a directory which was created with #o700 perms.