### PR TITLE
add find_by_pid

### DIFF
--- a/i3ipc/con.py
+++ b/i3ipc/con.py
@@ -285,17 +285,13 @@ class Con:
         except StopIteration:
             return None
 
-    def find_by_pid(self, pid: int) -> Optional['Con']:
-        """Finds a container with the given pid under this node.
+    def find_by_pid(self, pid: int) -> List['Con']:
+        """Finds all the containers under this node with this pid.
 
-        :returns: The container with this pid if it exists.
-        :rtype: :class:`Con` or :class:`None` if there is no container with
-            this pid.
+        :returns: A list of containers with this pid.
+        :rtype: list(:class:`Con`)
         """
-        try:
-            return next(c for c in self if c.pid == pid)
-        except StopIteration:
-            return None
+        return [c for c in self if c.pid == pid]
 
     def find_by_window(self, window: int) -> Optional['Con']:
         """Finds a container with the given window id under this node.

--- a/i3ipc/con.py
+++ b/i3ipc/con.py
@@ -285,6 +285,18 @@ class Con:
         except StopIteration:
             return None
 
+    def find_by_pid(self, pid: int) -> Optional['Con']:
+        """Finds a container with the given pid under this node.
+
+        :returns: The container with this pid if it exists.
+        :rtype: :class:`Con` or :class:`None` if there is no container with
+            this pid.
+        """
+        try:
+            return next(c for c in self if c.pid == pid)
+        except StopIteration:
+            return None
+
     def find_by_window(self, window: int) -> Optional['Con']:
         """Finds a container with the given window id under this node.
 


### PR DESCRIPTION
Add a way to find a container based on pid.

```python
In [1]: import i3ipc                                               

In [2]: i3 = i3ipc.Connection()                                    

In [3]: x = i3.get_tree().find_by_pid(1337)                        

In [4]: x.pid                                                      
Out[4]: 1337
``` 