### PR TITLE
i3-focus example fixes

### DIFF
--- a/examples/i3-focus/focus-window.py
+++ b/examples/i3-focus/focus-window.py
@@ -22,8 +22,6 @@ parser.add_argument('--socket-file', default='/tmp/i3-app-focus.socket', help='S
 sockets = Sockets(args.socket_file)
 containers_info = sockets.get_containers_history()
 
-containers_info_by_focused_app = Lists.find_all_by_focused_app(containers_info)
-
 i3 = i3ipc.Connection()
 menu = Menu(i3, args.menu, menu_args)
-menu.show_menu_container_info(containers_info_by_focused_app)
+menu.show_menu_container_info(containers_info)

--- a/examples/i3-focus/history-server.py
+++ b/examples/i3-focus/history-server.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
 
-# i3 get_tree does not contain information about focus throw all workspaces,
-# so scripts those use it can sort windows only with workspace groupping.
-# This server accumulates window focus history and does not pay attention on workspaces.
-
 import os
 import socket
 import selectors
@@ -11,6 +7,7 @@ import threading
 import json
 from argparse import ArgumentParser
 import i3ipc
+
 
 MAX_WIN_HISTORY = 15
 
@@ -39,11 +36,12 @@ class FocusWatcher:
             t.start()
 
     def _on_window_focus(self, i3conn, event):
-        if not self._is_window(event.container):
+        window_id = event.container.id
+        con = self.i3.get_tree().find_by_id(window_id)
+        if not self._is_window(con):
             return
 
         with self.window_list_lock:
-            window_id = event.container.id
             if window_id in self.window_list:
                 self.window_list.remove(window_id)
             self.window_list.insert(0, window_id)
@@ -69,6 +67,7 @@ class FocusWatcher:
                             "window": con.window,
                             "window_title": con.window_title,
                             "window_class": con.window_class,
+                            "window_role": con.window_role,
                             "focused": con.focused
                         })
 

--- a/examples/i3-focus/tools/app.py
+++ b/examples/i3-focus/tools/app.py
@@ -12,7 +12,30 @@ class App:
         return self._container_info["window_class"]
 
     def get_title(self):
-        # i3 = i3ipc.Connection()
-        # print("\n\n")
-        # print(vars(i3.get_tree().find_by_id(self._container_info["id"])))
+        window_class = self._container_info["window_class"]
+        method_name = '_get_title_' + window_class.replace('-', '_').lower()
+        method = getattr(self, method_name, self._get_title_based_on_class)
+        return method()
+
+    def _get_title_based_on_class(self):
+        return self._container_info["window_class"].replace('-', ' ').title()
+
+    def _get_title_based_on_title(self):
         return re.match(r"^.*?\s*(?P<title>[^-—]+)$", self._container_info["window_title"]).group("title")
+
+    # App specific functions
+
+    def _get_title_google_chrome(self):
+        is_browser_in_app_mode = self._container_info["window_role"] == "pop-up"
+        if is_browser_in_app_mode:
+            return self._get_title_based_on_title() + ' (Chrome)'
+
+        return self._get_title_based_on_class()
+
+    def _get_title_st_256color(self):
+        title = self._get_title_based_on_title()
+
+        if self._container_info["window_title"] != "Simple Terminal":
+            return title + ' (ST)'
+
+        return title

--- a/examples/i3-focus/tools/lists.py
+++ b/examples/i3-focus/tools/lists.py
@@ -21,7 +21,7 @@ class Lists:
 
         focused_app = App(focused_info)
 
-        focused_app_windows_by_class = list(filter(lambda i: i["window_class"] == focused_app.get_window_class(), infos))
+        focused_app_windows_by_class = list(filter(lambda i: App(i).get_title() == focused_app.get_title(), infos))
         return focused_app_windows_by_class
 
     @staticmethod
@@ -29,9 +29,3 @@ class Lists:
         for a in apps:
             if a.get_title() == title:
                 return a
-
-    @staticmethod
-    def find_container_info_by_title(title, infos):
-        for i in infos:
-            if i["window_title"] == title:
-                return i

--- a/examples/i3-focus/tools/menu.py
+++ b/examples/i3-focus/tools/menu.py
@@ -1,6 +1,6 @@
 from collections import deque
 from subprocess import check_output
-from . import Lists
+from . import Lists, App
 
 class Menu:
     def __init__(self, i3, menu, menu_args):
@@ -23,9 +23,26 @@ class Menu:
         con.command('focus');
 
     def show_menu_container_info(self, containers_info):
-        titles = list(map(lambda i: i["window_title"], containers_info))
-        selected_title = self.show_menu(titles)
-        selected_info = Lists.find_container_info_by_title(selected_title, containers_info)
+        titles = self._get_titles_with_app_prefix(containers_info)
+        titles_with_suffix = self._add_uniqu_suffix(titles)
+        infos_by_title = dict(zip(titles_with_suffix, containers_info))
+        selected_title = self.show_menu(titles_with_suffix)
+        selected_info = infos_by_title[selected_title]
         tree = self._i3.get_tree()
         con = tree.find_by_id(selected_info["id"])
         con.command('focus');
+
+    def _get_titles_with_app_prefix(self, containers_info):
+        return list(map(lambda i: App(i).get_title() + ': ' + i["window_title"], containers_info))
+
+    def _add_uniqu_suffix(self, titles):
+        counters = dict()
+        titles_with_suffix = []
+        for title in titles:
+            counters[title] = counters[title] + 1 if title in counters else 1
+            if counters[title] > 1:
+                title = f'{title} ({counters[title]})'
+
+            titles_with_suffix.append(title)
+
+        return titles_with_suffix


### PR DESCRIPTION
 - fix for non window containers in list
 - app title now based on window class instead of window title based
 - add index in title for windows with same titles
 - add script for flat window selection (without app grouping)
 - remove needless comments
