### PR TITLE
Extend `nth_window_in_workspace.py` to be able to cycle aswel

### DIFF
--- a/examples/nth_window_in_workspace.py
+++ b/examples/nth_window_in_workspace.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
+from itertools import cycle
 from subprocess import check_output
 import i3ipc
-
 
 def get_windows_on_ws(conn):
     return filter(lambda x: x.window, conn.get_tree().find_focused().workspace().descendents())
@@ -16,7 +16,7 @@ def window_is_visible(w):
     try:
         xprop = check_output(['xprop', '-id', str(w.window)]).decode()
     except FileNotFoundError:
-        raise SystemExit("The `xprop` utility is not found!" " Please install it and retry.")
+        raise SystemExit("The `xprop` utility is not found! Please install it and retry.")
 
     return '_NET_WM_STATE_HIDDEN' not in xprop
 
@@ -26,28 +26,54 @@ def pick_from_list(lst, n, alt=None):
     return lst[max(0, min(n, cnt - 1))] if cnt > 0 else alt
 
 
+def with_prev(gen):
+    """Takes a generator, and returns the elements, with the previous element.
+The first element only appears as previous. (and the last never-as)
+NOTE: maybe add optionals `w_first` and `w_last`"""
+    prev = next(gen)
+    for el in gen:
+        yield prev, el
+        prev = el
+
+
 def main(args):
     conn = i3ipc.Connection()
 
     workspace = workspace_by_name(conn, args.workspace)  # Find workspace.
     if workspace is None:
-        print("Workspace not found, making it.")
+        print("Workspace %s not found, making it."%args.workspace)
         conn.command("workspace " + args.workspace)
 
     else:
-        windows = workspace.leaves()  # Find windows in there.
+        windows =  list(workspace.leaves())  # Find windows in there.
         if args.filter == 'visible':
             windows = filter(window_is_visible, windows)
         elif args.filter != 'none':
             print("WARN: currently only support `visible` as window filter.")
 
-        window = pick_from_list(list(windows), args.nth)  # Pick correct window from there.
+        window = None
+        if args.select.isdigit():  # Pick `nth` window in there.
+            window = pick_from_list(list(windows), int(args.select))
+        # If any selected, cycle next.
+        elif args.select in ['c', 'r', 'cycle', 'reverse']:
+            cycle_windows = cycle(windows)
+            prev, cur_win = \
+                next(((p,w) for _i, (p, w)  # Where current window in cycle.
+                      in zip(range(len(windows)+1), with_prev(cycle_windows))
+                      if w.focused), (None,None))
+            if cur_win is None:  # Not in cycle, start with first.
+                window = pick_from_list(list(windows), 0)
+            else:
+                if args.select in ['c', 'cycle']:
+                    window = next(cycle_windows)
+                else:
+                    window = prev
 
-        if window is not None:
+        if window != None:
             print("Focussing %d" % window.window)
             conn.command('[id="%d"] focus' % window.window)
         else:
-            print("Did not find window(%d) going to workspace anyway." % args.nth)
+            print("Did not find window(%s) going to workspace anyway."%args.select)
             conn.command("workspace " + args.workspace)
 
     if args.mode != 'no':
@@ -63,11 +89,12 @@ if __name__ == '__main__':
         description="Program using i3ipc to select the nth window from a workspace.")
 
     parser.add_argument('workspace', help="Name of workspace to go to.")
-    parser.add_argument('nth',
-                        type=int,
-                        default=0,
-                        help="""Nth window in that workspace.
-If integer too high it will go to the last one, if no windows in there, goes to the workspace.""")
+    parser.add_argument('select',
+                        default='0',
+                        help="""If integer, that index in workspace.
+if `c`,`cycle` cycle forward if already on same workspace. `r`,`reverse` goes
+backward.
+If none apply goes to the first window in the workspace.""")
     parser.add_argument("--filter",
                         default='none',
                         help="filters to apply, i.e. `visible` or `none`(default)")

--- a/examples/nth_window_in_workspace.py
+++ b/examples/nth_window_in_workspace.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
+# * Can go straight to a window given a workspace, integer-index of window pair.
+#   (for instance for mapping keys to windows in a mode for that)
+# * Can also go to workspace, or cycle through the windows on that.
+#   (as opposed to going there and the button not having a use while there)
+
 from itertools import cycle
 from subprocess import check_output
 import i3ipc
@@ -86,7 +91,10 @@ if __name__ == '__main__':
 
     parser = ArgumentParser(
         prog='nth_window_in_workspace.py',
-        description="Program using i3ipc to select the nth window from a workspace.")
+        description="""Program to:
+* Select the nth window from a workspace. (i.e. for mapping each window to a key)
+* Go to workspace, or cycle through the windows of the workspace.
+  (improvement on just going to the workspace)""")
 
     parser.add_argument('workspace', help="Name of workspace to go to.")
     parser.add_argument('select',


### PR DESCRIPTION
Been other code with this functionality, but didn't realize i hadn't pull-requested it. However, it's better to modify this file i think.

The commandline argument `nth` can be an integer, working as before, it can be `c`/`cycle` in which case if you're already in that workspace, it cycles you through it. (`r`/reverse` goes backwards)

This is basically so you can use a button to go to a workspace, and you can just hit the same button some more to get the right window. (i.e. the button doesn't go useless if you're already on the workspace)