### PR TITLE
focus-last.py: Terminate threads and re-instantiate after a broken pipe

### DIFF
--- a/examples/focus-last.py
+++ b/examples/focus-last.py
@@ -15,7 +15,9 @@ MAX_WIN_HISTORY = 15
 
 
 class FocusWatcher:
+    global focus_watcher
     def __init__(self):
+        self.alive = True 
         self.i3 = i3ipc.Connection()
         self.i3.on('window::focus', self.on_window_focus)
         # Make a directory with permissions that restrict access to
@@ -52,24 +54,33 @@ class FocusWatcher:
             data = conn.recv(1024)
             if data == b'switch':
                 with self.window_list_lock:
-                    tree = self.i3.get_tree()
-                    windows = set(w.id for w in tree.leaves())
-                    for window_id in self.window_list[1:]:
-                        if window_id not in windows:
-                            self.window_list.remove(window_id)
-                        else:
-                            self.i3.command('[con_id=%s] focus' % window_id)
-                            break
+                    try: 
+                        tree = self.i3.get_tree()
+                        windows = set(w.id for w in tree.leaves())
+                        for window_id in self.window_list[1:]:
+                            if window_id not in windows:
+                                self.window_list.remove(window_id)
+                            else:
+                                self.i3.command('[con_id=%s] focus' % window_id)
+                                break
+                    except BrokenPipeError:
+                        print("Caught broken pipe, restarting...")
+                        self.alive = False 
             elif not data:
                 selector.unregister(conn)
                 conn.close()
 
         selector.register(self.listening_socket, selectors.EVENT_READ, accept)
 
-        while True:
+        while self.alive:
             for key, event in selector.select():
                 callback = key.data
                 callback(key.fileobj)
+                
+        self.i3.main_quit() 
+        focus_watcher = FocusWatcher()
+        focus_watcher.run()
+        del(self) 
 
     def run(self):
         t_i3 = threading.Thread(target=self.launch_i3)


### PR DESCRIPTION
When restarting i3 the socket connection with the script is lost (_broken pipe_), requiring manual restart of the script and also optionally killing the previous rogue instance(s).

This PR invents a stopping mechanism for the threads which then re-instantiate `FocusWatcher` after a broken pipe exception is detected, thereby providing uninterrupted operation of the script between restarts. (It takes a few seconds until it re-establishes)

The last remembered window is lost but registry continues on the new session as the user keeps changing focus. 
Maybe someone else can assist to implement persistent history? 

Fixes and improvements are welcome