### PR TITLE
Fix spelling of auto_reconnect property

### DIFF
--- a/i3ipc/aio/connection.py
+++ b/i3ipc/aio/connection.py
@@ -287,7 +287,7 @@ class Connection:
         return self._socket_path
 
     @property
-    def auto_reconect(self) -> bool:
+    def auto_reconnect(self) -> bool:
         """Whether this ``Connection`` will attempt to reconnect when the
         connection to the socket is broken.
 


### PR DESCRIPTION
Unfortunately, this may break code relying on this spelling. Maybe not worth it changing it.