### PR TITLE
Add decorator syntax for event handlers

### DIFF
--- a/i3ipc/aio/connection.py
+++ b/i3ipc/aio/connection.py
@@ -514,7 +514,17 @@ class Connection:
 
         await self._loop.sock_sendall(self._sub_socket, _pack(MessageType.SUBSCRIBE, payload))
 
-    def on(self, event: Union[Event, str], handler: Callable[['Connection', IpcBaseEvent], None]):
+    def on(self, event: Union[Event, str], handler: Callable[['Connection', IpcBaseEvent], None] = None):
+        def on_wrapped(handler):
+            self._on(event, handler)
+            return handler
+
+        if handler:
+            return on_wrapped(handler)
+        else:
+            return on_wrapped
+
+    def _on(self, event: Union[Event, str], handler: Callable[['Connection', IpcBaseEvent], None]):
         """Subscribe to the event and call the handler when it is emitted by
         the i3 ipc.
 

--- a/i3ipc/connection.py
+++ b/i3ipc/connection.py
@@ -406,7 +406,17 @@ class Connection:
         """
         self._pubsub.unsubscribe(handler)
 
-    def on(self, event: Union[Event, str], handler: Callable[['Connection', IpcBaseEvent], None]):
+    def on(self, event: Union[Event, str], handler: Callable[['Connection', IpcBaseEvent], None] = None):
+        def on_wrapped(handler):
+            self._on(event, handler)
+            return handler
+
+        if handler:
+            return on_wrapped(handler)
+        else:
+            return on_wrapped
+
+    def _on(self, event: Union[Event, str], handler: Callable[['Connection', IpcBaseEvent], None]):
         """Subscribe to the event and call the handler when it is emitted by
         the i3 ipc.
 


### PR DESCRIPTION
This PR provides an alternative syntax to define event handlers, using function decorators.

The syntax without this PR looks like this:
```py
    sway = await Connection().connect()

    async def on_window_focus(sway, e):
        pass

    sway.on(Event.WINDOW_FOCUS, on_window_focus)
```
This is still supported with the changes introduced in this PR.

The only difference is that this new syntax is now also available:
```py
    sway = await Connection().connect()

    @sway.on(Event.WINDOW_FOCUS)
    async def on_window_focus(sway, e):
        pass
```

It is also possible to stack multiple decorators on the same event handler:
```py
    sway = await Connection().connect()

    @sway.on(Event.WINDOW_FOCUS)
    @sway.on(Event.WINDOW_CLOSE)
    @sway.on(Event.WINDOW_TITLE)
    async def on_window_event(sway, e):
        pass
```