### PR TITLE
Removed superfluous python-xlib dependency

### DIFF
--- a/i3ipc/_private/sync.py
+++ b/i3ipc/_private/sync.py
@@ -1,8 +1,4 @@
-from Xlib import display
-from Xlib.protocol import event
-from Xlib import X
 import random
-
 
 class Synchronizer:
     def __init__(self):

--- a/i3ipc/aio/connection.py
+++ b/i3ipc/aio/connection.py
@@ -7,8 +7,6 @@ from .. import con
 import os
 import json
 from typing import Optional, List, Tuple, Callable, Union
-from Xlib import display, X
-from Xlib.error import DisplayError
 import struct
 import socket
 import logging
@@ -200,22 +198,6 @@ async def _find_socket_path() -> Optional[str]:
     socket_path = os.environ.get('SWAYSOCK')
     if socket_path:
         logger.info('got socket path from SWAYSOCK env variable: %s', socket_path)
-        if exists(socket_path):
-            return socket_path
-
-    # next try the root window property
-    try:
-        d = display.Display()
-        atom = d.get_atom('I3_SOCKET_PATH')
-        root = d.screen().root
-        prop = root.get_full_property(atom, X.AnyPropertyType)
-        if prop and prop.value:
-            socket_path = prop.value.decode()
-    except DisplayError as e:
-        logger.info('could not get i3 socket path from root atom', exc_info=e)
-
-    if socket_path:
-        logger.info('got socket path from root atom: %s', socket_path)
         if exists(socket_path):
             return socket_path
 

--- a/i3ipc/connection.py
+++ b/i3ipc/connection.py
@@ -14,9 +14,6 @@ import socket
 import os
 from threading import Timer, Lock
 import time
-import Xlib
-import Xlib.display
-from Xlib.error import DisplayError
 import logging
 from subprocess import run, PIPE
 
@@ -86,20 +83,6 @@ class Connection:
             logger.info('got socket path from SWAYSOCK env variable: %s', socket_path)
             return socket_path
 
-        try:
-            disp = Xlib.display.Display()
-            root = disp.screen().root
-            i3atom = disp.intern_atom("I3_SOCKET_PATH")
-            prop = root.get_full_property(i3atom, Xlib.X.AnyPropertyType)
-            if prop and prop.value:
-                socket_path = prop.value.decode()
-        except DisplayError as e:
-            logger.info('could not get i3 socket path from root atom', exc_info=e)
-
-        if socket_path:
-            logger.info('got socket path from root atom: %s', socket_path)
-            return socket_path
-
         for binary in ('i3', 'sway'):
             try:
                 process = run([binary, '--get-socketpath'], stdout=PIPE, stderr=PIPE)
@@ -116,7 +99,7 @@ class Connection:
                 logger.info('could not get i3 socket path from `%s` binary', binary, exc_info=e)
                 continue
 
-        logger.info('could not find i3 socket path')
+        logger.info('could not find i3/sway socket path')
         return None
 
     def _sync(self):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 from setuptools import setup, find_packages
 
 REQUIRES_PYTHON = '>=3.4.0'
-REQUIRED = ['python-xlib']
+REQUIRED = []
 EXTRAS = {}
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/test/aio/window.py
+++ b/test/aio/window.py
@@ -2,7 +2,6 @@ from Xlib import X, Xutil
 from Xlib.display import Display
 from threading import Thread
 
-
 class Window(object):
     def __init__(self, display=None):
         if display is None:


### PR DESCRIPTION
Addresses #198. 

This was a feature released in 1.3.0 (see changelog), but then regressed by a merge request in 2.0.1, #116 

Someone must have realized that this replacement method was a bad idea, because the current branch is back to using the `i3/sway --get-socketpath` method. This revert was however incomplete, as the method added to #116 still remains, along with the `python-xlib` dependency. 

Anyhow, the pull request purges any use of `python-xlib`. It's still used in testing, but there the package is separately installed when creating the docker testing image. 

TL;DR: Don't accept pull request by script kiddies that address non-existent issues, regress features, and add package dependencies; all in the name of "removing a subprocess call" by replacing it with 5 method calls to `python-xlib`.  