### PR TITLE
Adds py.typed and fixes mypy issues

### DIFF
--- a/i3ipc/con.py
+++ b/i3ipc/con.py
@@ -181,7 +181,7 @@ class Con:
         :returns: Whether this is a floating node
         :rtype: bool
         """
-        if self.floating in ['user_on', 'auto_on']:
+        if self.floating in ['user_on', 'auto_on']: # type: ignore[attr-defined]
             return True
         return False
 
@@ -249,7 +249,7 @@ class Con:
             string.
         :rtype: list(:class:`CommandReply <i3ipc.CommandReply>`)
         """
-        return self._conn.command('[con_id="{}"] {}'.format(self.id, command))
+        return self._conn.command('[con_id="{}"] {}'.format(self.id, command)) # type: ignore[attr-defined]
 
     def command_children(self, command: str) -> List[replies.CommandReply]:
         """Runs a command on the immediate children of the currently selected
@@ -261,13 +261,13 @@ class Con:
         :rtype: list(:class:`CommandReply <i3ipc.CommandReply>`)
         """
         if not len(self.nodes):
-            return
+            return []
 
         commands = []
         for c in self.nodes:
             commands.append('[con_id="{}"] {};'.format(c.id, command))
 
-        self._conn.command(' '.join(commands))
+        return self._conn.command(' '.join(commands))
 
     def workspaces(self) -> List['Con']:
         """Gets a list of workspace containers for this tree.
@@ -393,8 +393,8 @@ class Con:
             pattern.
         :rtype: list(:class:`Con`)
         """
-        pattern = re.compile(pattern)
-        return [c for c in self if any(pattern.search(mark) for mark in c.marks)]
+        compiled_pattern = re.compile(pattern)
+        return [c for c in self if any(compiled_pattern.search(mark) for mark in c.marks)]
 
     def find_fullscreen(self) -> List['Con']:
         """Finds all the containers under this node that are in fullscreen
@@ -425,7 +425,7 @@ class Con:
 
         return ret
 
-    def scratchpad(self) -> 'Con':
+    def scratchpad(self) -> Optional['Con']:
         """Finds the scratchpad container.
 
         :returns: The scratchpad container.

--- a/i3ipc/connection.py
+++ b/i3ipc/connection.py
@@ -232,7 +232,7 @@ class Connection:
         data = json.loads(data)
         return VersionReply(data)
 
-    def get_bar_config(self, bar_id: str = None) -> Optional[BarConfigReply]:
+    def get_bar_config(self, bar_id: Optional[str] = None) -> Optional[BarConfigReply]:
         """Gets the bar configuration specified by the id.
 
         :param bar_id: The bar id to get the configuration for. If not given,
@@ -391,7 +391,7 @@ class Connection:
 
     def on(self,
            event: Union[Event, str],
-           handler: Callable[['Connection', IpcBaseEvent], None] = None):
+           handler: Optional[Callable[['Connection', IpcBaseEvent], None]] = None):
         def on_wrapped(handler):
             self._on(event, handler)
             return handler
@@ -410,7 +410,7 @@ class Connection:
         :param handler: The event handler to call.
         :type handler: :class:`Callable`
         """
-        if type(event) is Event:
+        if isinstance(event, Event):
             event = event.value
 
         event = event.replace('-', '_')
@@ -426,7 +426,7 @@ class Connection:
             self._pubsub.subscribe(event, handler)
             return
 
-        event_type = 0
+        event_type: Optional[EventType] = None
         if base_event == 'workspace':
             event_type = EventType.WORKSPACE
         elif base_event == 'output':

--- a/i3ipc/events.py
+++ b/i3ipc/events.py
@@ -45,7 +45,7 @@ class Event(Enum):
     INPUT_REMOVED = 'input::removed'
 
 
-Event._subscribable_events = [e for e in Event if '::' not in e.value]
+Event._subscribable_events = [e for e in Event if '::' not in e.value] # type: ignore[attr-defined]
 
 
 class WorkspaceEvent(IpcBaseEvent):

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     include_package_data=True,
+    package_data={"i3ipc": ["py.typed"]},
     license='BSD',
     keywords='i3 i3wm extensions add-ons',
     classifiers=[

--- a/test/aio/test_ticks.py
+++ b/test/aio/test_ticks.py
@@ -1,3 +1,6 @@
+from typing import List
+
+from i3ipc.events import TickEvent
 from .ipctest import IpcTest
 
 import pytest
@@ -5,7 +8,7 @@ import asyncio
 
 
 class TestTicks(IpcTest):
-    events = []
+    events: List[TickEvent] = []
 
     async def on_tick(self, i3, e):
         self.events.append(e)

--- a/test/test_shutdown_event.py
+++ b/test/test_shutdown_event.py
@@ -1,14 +1,16 @@
 from threading import Timer
+from typing import List
+from i3ipc.events import ShutdownEvent
 from ipctest import IpcTest
 
 
 class TestShutdownEvent(IpcTest):
-    events = []
+    events: List[ShutdownEvent] = []
 
     def restart_func(self, i3):
         i3.command('restart')
 
-    def on_shutdown(self, i3, e):
+    def on_shutdown(self, i3, e: ShutdownEvent):
         self.events.append(e)
         assert i3._wait_for_socket()
         if len(self.events) == 1:

--- a/test/test_ticks.py
+++ b/test/test_ticks.py
@@ -1,10 +1,12 @@
+from typing import List
+from i3ipc.events import TickEvent
 from ipctest import IpcTest
 
 
 class TestTicks(IpcTest):
-    events = []
+    events: List[TickEvent] = []
 
-    def on_tick(self, i3, e):
+    def on_tick(self, i3, e: TickEvent):
         self.events.append(e)
         if len(self.events) == 3:
             i3.main_quit()


### PR DESCRIPTION
i3ipc now has no complaints from mypy. This fixes https://github.com/altdesktop/i3ipc-python/issues/187. 

My current test setup is:

0) Do existing i3ipc-python setup
1) `pip install mypy types-python-xlib`
2) Go into the `test` folder.
3) Repeatedly run `(cd .. && pip install . && python -m mypy . --exclude build --exclude examples --exclude docs --exclude setup.py)` as I made changes until it stopped breaking.

https://github.com/jazzband/dj-database-url/pull/215/commits/7ee1eea3b59afb3d4899c3694de6ec3fcd0d33d0 demos this sort of check in CI environment, but can't do that here yet because of #204.